### PR TITLE
Enable CORS for GET requests to /api/v1/denuncias

### DIFF
--- a/listahu/settings.py.example
+++ b/listahu/settings.py.example
@@ -48,10 +48,12 @@ INSTALLED_APPS = (
     'django.contrib.staticfiles',
     'backend',
     'rest_framework',
+    'corsheaders'
 )
 
 MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -122,3 +124,8 @@ REST_FRAMEWORK = {
     'PAGINATE_BY': 50,
     'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
 }
+
+# Enable CORS for GET request to /api/v1/denuncias only
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = r'/api/v1/denuncias.*$'
+CORS_ALLOW_METHODS = ('GET')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ psycopg2==2.6
 vobject==0.6.6
 django-adminactions
 django-admin-bootstrapped
+django-cors-headers


### PR DESCRIPTION
Enable CORS in order to make request from other domains.
